### PR TITLE
Add billing support

### DIFF
--- a/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/soap/client/Opa12AssessClientConfig.java
+++ b/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/soap/client/Opa12AssessClientConfig.java
@@ -25,7 +25,10 @@ public class Opa12AssessClientConfig {
    private static final Logger logger = LoggerFactory.getLogger(Opa12AssessClientConfig.class);
 
    @Value("${client.opa12Assess.address}")
-   private String address;
+   private String meansAddress;
+
+   @Value("${client.opa12Assess.billing.address}")
+   private String billingAddress;
 
    @Value("${client.opa12Assess.security.user.name}")
    private String userName;
@@ -33,9 +36,18 @@ public class Opa12AssessClientConfig {
    @Autowired
    private ClientPasswordCallback clientPasswordCallback;
 
-   @Bean(name = "opa12AssessServiceProxy")
-   public OdsAssessServiceGeneric122MeansAssessmentV12Type opa12AssessServiceProxy() {
+   @Bean(name = "opa12MeansAssessServiceProxy")
+   public OdsAssessServiceGeneric122MeansAssessmentV12Type opa12MeansAssessServiceProxy() {
+      return getOdsAssessServiceGeneric122MeansAssessmentV12Type(meansAddress);
+   }
+   
+   @Bean(name = "opa12BillingAssessServiceProxy")
+   public OdsAssessServiceGeneric122MeansAssessmentV12Type opa12BillingAssessServiceProxy() {
+      return getOdsAssessServiceGeneric122MeansAssessmentV12Type(billingAddress);
+   }
 
+   private OdsAssessServiceGeneric122MeansAssessmentV12Type getOdsAssessServiceGeneric122MeansAssessmentV12Type(
+       String address) {
       logger.debug("Address:" + address);
 
       JaxWsProxyFactoryBean jaxWsProxyFactoryBean = new JaxWsProxyFactoryBean();
@@ -56,5 +68,6 @@ public class Opa12AssessClientConfig {
       client.getOutInterceptors().add(new WSS4JOutInterceptor(outProps));
       return proxy;
    }
+
 
 }

--- a/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/soap/client/Opa12AssessClientConfig.java
+++ b/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/soap/client/Opa12AssessClientConfig.java
@@ -24,7 +24,7 @@ import com.oracle.determinations.server._12_2.rulebase.assess.types.OdsAssessSer
 public class Opa12AssessClientConfig {
    private static final Logger logger = LoggerFactory.getLogger(Opa12AssessClientConfig.class);
 
-   @Value("${client.opa12Assess.address}")
+   @Value("${client.opa12Assess.means.address}")
    private String meansAddress;
 
    @Value("${client.opa12Assess.billing.address}")
@@ -40,7 +40,7 @@ public class Opa12AssessClientConfig {
    public OdsAssessServiceGeneric122MeansAssessmentV12Type opa12MeansAssessServiceProxy() {
       return getOdsAssessServiceGeneric122MeansAssessmentV12Type(meansAddress);
    }
-   
+
    @Bean(name = "opa12BillingAssessServiceProxy")
    public OdsAssessServiceGeneric122MeansAssessmentV12Type opa12BillingAssessServiceProxy() {
       return getOdsAssessServiceGeneric122MeansAssessmentV12Type(billingAddress);

--- a/opa_10_12_transform/src/main/resources/application-dev.properties
+++ b/opa_10_12_transform/src/main/resources/application-dev.properties
@@ -1,5 +1,5 @@
 logging.config=classpath:log4j2-dev.xml
-client.opa12Assess.address = http://ds01za003:7703/devopa10/determinations-server/assess/soap/generic/12.2/Means__Assessment__v12
+client.opa12Assess.means.address = http://ds01za003:7703/devopa10/determinations-server/assess/soap/generic/12.2/Means__Assessment__v12
 client.opa12Assess.security.user.name = admin
 client.opa12Assess.security.user.password = Welcome123
         

--- a/opa_10_12_transform/src/main/resources/application-local.properties
+++ b/opa_10_12_transform/src/main/resources/application-local.properties
@@ -1,5 +1,5 @@
 logging.config=classpath:log4j2-local.xml
-client.opa12Assess.address = http://localhost:8787/determinations-server/assess/soap/generic/12.2/MeansAssessment
+client.opa12Assess.means.address = http://localhost:8787/determinations-server/assess/soap/generic/12.2/MeansAssessment
 client.opa12Assess.billing.address=http://localhost:8787/determinations-server/assess/soap/generic/12.2/BillingAssessment
 
 client.opa12Assess.security.user.name = admin

--- a/opa_10_12_transform/src/main/resources/application-local.properties
+++ b/opa_10_12_transform/src/main/resources/application-local.properties
@@ -1,7 +1,9 @@
 logging.config=classpath:log4j2-local.xml
-client.opa12Assess.address = http://ds01za005:7703/sitopa10/determinations-server/assess/soap/generic/12.2/Means__Assessment__v12
+client.opa12Assess.address = http://localhost:8787/determinations-server/assess/soap/generic/12.2/MeansAssessment
+client.opa12Assess.billing.address=http://localhost:8787/determinations-server/assess/soap/generic/12.2/BillingAssessment
+
 client.opa12Assess.security.user.name = admin
-client.opa12Assess.security.user.password = Welcome123
+client.opa12Assess.security.user.password = Passw0rd
         
         
 server.opa10Assess.path: /opadrulebase

--- a/opa_10_12_transform/src/main/resources/application-prod.properties
+++ b/opa_10_12_transform/src/main/resources/application-prod.properties
@@ -1,5 +1,5 @@
 logging.config=classpath:log4j2-dev.xml
-client.opa12Assess.address = u01/oracle/prod/opa12prod/mid/1213/user_projects/domains/opa12prod_domain/connector-logs
+client.opa12Assess.means.address = u01/oracle/prod/opa12prod/mid/1213/user_projects/domains/opa12prod_domain/connector-logs
 client.opa12Assess.security.user.name = admin
 client.opa12Assess.security.user.password = welcome1
         

--- a/opa_10_12_transform/src/main/resources/application-stage.properties
+++ b/opa_10_12_transform/src/main/resources/application-stage.properties
@@ -1,5 +1,5 @@
 logging.config=classpath:log4j2-local.xml
-client.opa12Assess.address = http://c17opa12-e10.lab.gov:7055/rulesbeta_18a/determinations-server/assess/soap/generic/12.2/MeansAssessment
+client.opa12Assess.means.address = http://c17opa12-e10.lab.gov:7055/rulesbeta_18a/determinations-server/assess/soap/generic/12.2/MeansAssessment
 client.opa12Assess.security.user.name = admin
 client.opa12Assess.security.user.password = welcome1
 

--- a/opa_10_12_transform/src/main/resources/application-uat.properties
+++ b/opa_10_12_transform/src/main/resources/application-uat.properties
@@ -1,5 +1,5 @@
 logging.config=classpath:log4j2-sit.xml
-client.opa12Assess.address = http://c18opa12-e11.lab.gov:7056/rules/determinations-server/assess/soap/generic/12.2/Means__Assessment__v12
+client.opa12Assess.means.address = http://c18opa12-e11.lab.gov:7056/rules/determinations-server/assess/soap/generic/12.2/Means__Assessment__v12
 client.opa12Assess.security.user.name = admin
 client.opa12Assess.security.user.password = welcome1
         


### PR DESCRIPTION
**What**
Add support for billing

**Why**
This adapter only currently works with means assessments, but needs to be able to handle billing assessment requests too.

At the moment this has only been tested locally. The properties files for the other environments will need to be updated to add the URL for the billing assessment.