### PR TITLE
Reformat the whole code base with a consistent style

### DIFF
--- a/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/AssessAdapterConfig.java
+++ b/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/AssessAdapterConfig.java
@@ -2,31 +2,29 @@ package uk.gov.justice.laa.ccms;
 
 import java.util.Map;
 import java.util.stream.Collectors;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
 import uk.gov.justice.laa.ccms.service.OPAEntity;
 import uk.gov.justice.laa.ccms.service.ReferenceDataService;
 
 @Configuration
 public class AssessAdapterConfig {
-	
-	private ReferenceDataService referenceDataService;
-	
-	@Value("${ccms.ref-data-file}")
-	private String opaEntityFielName;
-	
-	@Autowired
-	public AssessAdapterConfig(ReferenceDataService referenceDataService) {
-		this.referenceDataService = referenceDataService;
-	}
-	
-	@Bean
-	public Map<String,OPAEntity> loadOpaEntities(){
-		return referenceDataService.loadObjectList(OPAEntity.class, opaEntityFielName)
-				.stream().collect(Collectors.toMap(OPAEntity::getEntityCode, e -> e));
-	}
+
+  private final ReferenceDataService referenceDataService;
+
+  @Value("${ccms.ref-data-file}")
+  private String opaEntityFielName;
+
+  @Autowired
+  public AssessAdapterConfig(ReferenceDataService referenceDataService) {
+    this.referenceDataService = referenceDataService;
+  }
+
+  @Bean
+  public Map<String, OPAEntity> loadOpaEntities() {
+    return referenceDataService.loadObjectList(OPAEntity.class, opaEntityFielName)
+        .stream().collect(Collectors.toMap(OPAEntity::getEntityCode, e -> e));
+  }
 }

--- a/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/SpringCxfApplication.java
+++ b/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/SpringCxfApplication.java
@@ -7,11 +7,12 @@ import org.springframework.boot.web.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.web.WebApplicationInitializer;
 
-@SpringBootApplication(exclude = { SecurityAutoConfiguration.class })
-@ComponentScan(basePackages = { "com.oracle.determinations.server", "uk.gov.justice.laa.ccms" })
-public class SpringCxfApplication extends SpringBootServletInitializer implements WebApplicationInitializer {
+@SpringBootApplication(exclude = {SecurityAutoConfiguration.class})
+@ComponentScan(basePackages = {"com.oracle.determinations.server", "uk.gov.justice.laa.ccms"})
+public class SpringCxfApplication extends SpringBootServletInitializer implements
+    WebApplicationInitializer {
 
-   public static void main(String[] args) {
-      SpringApplication.run(SpringCxfApplication.class, args);
-   }
+  public static void main(String[] args) {
+    SpringApplication.run(SpringCxfApplication.class, args);
+  }
 }

--- a/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/endpoint/EndpointConfig.java
+++ b/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/endpoint/EndpointConfig.java
@@ -1,10 +1,9 @@
 package uk.gov.justice.laa.ccms.endpoint;
 
+import com.oracle.determinations.server._10_0.rulebase.types.OpadsRulebaseGeneric;
 import java.util.HashMap;
 import java.util.Map;
-
 import javax.xml.ws.Endpoint;
-
 import org.apache.cxf.Bus;
 import org.apache.cxf.interceptor.LoggingInInterceptor;
 import org.apache.cxf.interceptor.LoggingOutInterceptor;
@@ -16,44 +15,42 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import com.oracle.determinations.server._10_0.rulebase.types.OpadsRulebaseGeneric;
-
 @SuppressWarnings("deprecation")
 @Configuration
 public class EndpointConfig {
 
-   @Autowired
-   private Bus bus;
+  @Autowired
+  private Bus bus;
 
-   @Value("${server.opa10Assess.security.user.name}")
-   private String userName;
+  @Value("${server.opa10Assess.security.user.name}")
+  private String userName;
 
-   @Value("${server.opa10Assess.path}")
-   private String path;
+  @Value("${server.opa10Assess.path}")
+  private String path;
 
-   @Autowired
-   private ServerPasswordCallback serverPasswordCallback;
+  @Autowired
+  private ServerPasswordCallback serverPasswordCallback;
 
-   @Autowired
-   private OpadsRulebaseGeneric opadsRulebaseGeneric;
+  @Autowired
+  private OpadsRulebaseGeneric opadsRulebaseGeneric;
 
-   @Bean
-   public Endpoint endpoint() {
-      EndpointImpl endpoint = new EndpointImpl(bus, opadsRulebaseGeneric);
-      endpoint.publish(path);
-      
-      endpoint.getInInterceptors().add(new LoggingInInterceptor());
-      endpoint.getOutInterceptors().add(new LoggingOutInterceptor());
+  @Bean
+  public Endpoint endpoint() {
+    EndpointImpl endpoint = new EndpointImpl(bus, opadsRulebaseGeneric);
+    endpoint.publish(path);
 
-      Map<String, Object> inProps = new HashMap<String, Object>();
-      inProps.put(WSHandlerConstants.ACTION, WSConstants.USERNAME_TOKEN_LN);
+    endpoint.getInInterceptors().add(new LoggingInInterceptor());
+    endpoint.getOutInterceptors().add(new LoggingOutInterceptor());
 
-      inProps.put(WSHandlerConstants.PASSWORD_TYPE, WSConstants.PW_TEXT);
-      inProps.put(WSHandlerConstants.USER, userName);
-      inProps.put(WSHandlerConstants.PW_CALLBACK_REF, serverPasswordCallback);
+    Map<String, Object> inProps = new HashMap<String, Object>();
+    inProps.put(WSHandlerConstants.ACTION, WSConstants.USERNAME_TOKEN_LN);
 
-      //endpoint.getInInterceptors().add(new WSS4JInInterceptor(inProps));
+    inProps.put(WSHandlerConstants.PASSWORD_TYPE, WSConstants.PW_TEXT);
+    inProps.put(WSHandlerConstants.USER, userName);
+    inProps.put(WSHandlerConstants.PW_CALLBACK_REF, serverPasswordCallback);
 
-      return endpoint;
-   }
+    //endpoint.getInInterceptors().add(new WSS4JInInterceptor(inProps));
+
+    return endpoint;
+  }
 }

--- a/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/endpoint/OpadsRulebaseGenericImpl.java
+++ b/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/endpoint/OpadsRulebaseGenericImpl.java
@@ -1,21 +1,18 @@
 package uk.gov.justice.laa.ccms.endpoint;
 
+import com.oracle.determinations.server._10_0.rulebase.types.AssessRequest;
+import com.oracle.determinations.server._10_0.rulebase.types.AssessResponse;
 import com.oracle.determinations.server._10_0.rulebase.types.AttributeOutcome;
 import com.oracle.determinations.server._10_0.rulebase.types.Entity;
+import com.oracle.determinations.server._10_0.rulebase.types.ErrorResponse;
 import com.oracle.determinations.server._10_0.rulebase.types.ListEntity;
+import com.oracle.determinations.server._10_0.rulebase.types.OpadsRulebaseGeneric;
+import com.oracle.determinations.server._12_2.rulebase.assess.types.OdsAssessServiceGeneric122MeansAssessmentV12Type;
 import java.util.List;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import com.oracle.determinations.server._10_0.rulebase.types.AssessRequest;
-import com.oracle.determinations.server._10_0.rulebase.types.AssessResponse;
-import com.oracle.determinations.server._10_0.rulebase.types.ErrorResponse;
-import com.oracle.determinations.server._10_0.rulebase.types.OpadsRulebaseGeneric;
-import com.oracle.determinations.server._12_2.rulebase.assess.types.OdsAssessServiceGeneric122MeansAssessmentV12Type;
-
 import uk.gov.justice.laa.ccms.mapper.AssessRequestMapper;
 import uk.gov.justice.laa.ccms.mapper.AssessResponseMapper;
 import uk.gov.justice.laa.ccms.mapper.EntityLevelRelocationService;
@@ -23,67 +20,69 @@ import uk.gov.justice.laa.ccms.mapper.EntityLevelRelocationService;
 @Component
 public class OpadsRulebaseGenericImpl implements OpadsRulebaseGeneric {
 
-   private static final Logger logger = LoggerFactory.getLogger(OpadsRulebaseGenericImpl.class);
+  private static final Logger logger = LoggerFactory.getLogger(OpadsRulebaseGenericImpl.class);
 
-   @Autowired
-   private AssessRequestMapper assessRequestMapper;
+  @Autowired
+  private AssessRequestMapper assessRequestMapper;
 
-   @Autowired
-   private AssessResponseMapper assessResponseMapper;
+  @Autowired
+  private AssessResponseMapper assessResponseMapper;
 
-   @Autowired
-   private OdsAssessServiceGeneric122MeansAssessmentV12Type opa12MeansAssessServiceProxy;
+  @Autowired
+  private OdsAssessServiceGeneric122MeansAssessmentV12Type opa12MeansAssessServiceProxy;
 
-   @Autowired
-   private OdsAssessServiceGeneric122MeansAssessmentV12Type opa12BillingAssessServiceProxy;
+  @Autowired
+  private OdsAssessServiceGeneric122MeansAssessmentV12Type opa12BillingAssessServiceProxy;
 
-   @Autowired
-   private EntityLevelRelocationService entityLevelRelocationService;
+  @Autowired
+  private EntityLevelRelocationService entityLevelRelocationService;
 
-   
-   @Override
-   public AssessResponse assess(AssessRequest assessRequest) throws ErrorResponse {
 
-      logger.debug("Assess Service" + assessRequest.toString());
+  @Override
+  public AssessResponse assess(AssessRequest assessRequest) throws ErrorResponse {
 
-      com.oracle.determinations.server._12_2.rulebase.assess.types.AssessRequest request = assessRequestMapper.map(assessRequest);
+    logger.debug("Assess Service" + assessRequest.toString());
 
-      entityLevelRelocationService.moveGlobalAttributesAndRelationsToBaseLevel(request);
+    com.oracle.determinations.server._12_2.rulebase.assess.types.AssessRequest request = assessRequestMapper
+        .map(assessRequest);
 
-      entityLevelRelocationService.moveSubEntitiesToLowerLevel(request);
+    entityLevelRelocationService.moveGlobalAttributesAndRelationsToBaseLevel(request);
 
-      com.oracle.determinations.server._12_2.rulebase.assess.types.AssessResponse assess12Response;
-      if(isMeansAssessment(assessRequest)) {
-         assess12Response = opa12MeansAssessServiceProxy.assess(request);
-      } else {
-         assess12Response = opa12BillingAssessServiceProxy.assess(request);
+    entityLevelRelocationService.moveSubEntitiesToLowerLevel(request);
+
+    com.oracle.determinations.server._12_2.rulebase.assess.types.AssessResponse assess12Response;
+    if (isMeansAssessment(assessRequest)) {
+      assess12Response = opa12MeansAssessServiceProxy.assess(request);
+    } else {
+      assess12Response = opa12BillingAssessServiceProxy.assess(request);
+    }
+
+    entityLevelRelocationService.moveGlobalEntityToLowerLevel(assess12Response,
+        entityLevelRelocationService.getGlobalEntityId(assessRequest));
+
+    entityLevelRelocationService.moveSubEntitiesToUpperLevel(assess12Response);
+
+    AssessResponse response = assessResponseMapper.map(assess12Response);
+
+    entityLevelRelocationService.mapOpa10Relationships(response);
+
+    return response;
+  }
+
+  boolean isMeansAssessment(AssessRequest assessRequest) {
+    List<ListEntity> listEntityList = assessRequest.getSessionData().getListEntity();
+    for (ListEntity listEntity : listEntityList) {
+      List<Entity> entityList = listEntity.getEntity();
+      for (Entity entity : entityList) {
+        List<AttributeOutcome> attributes = entity.getAttributeOutcome();
+        for (AttributeOutcome attributeOutcome : attributes) {
+          if (attributeOutcome.getId().equals("MEANS_CALCULATIONS")) {
+            return true;
+          }
+        }
       }
-
-      entityLevelRelocationService.moveGlobalEntityToLowerLevel(assess12Response, entityLevelRelocationService.getGlobalEntityId(assessRequest));
-
-      entityLevelRelocationService.moveSubEntitiesToUpperLevel(assess12Response);
-
-      AssessResponse response = assessResponseMapper.map(assess12Response);
-      
-      entityLevelRelocationService.mapOpa10Relationships(response);
-
-      return response;
-   }
-
-   boolean isMeansAssessment(AssessRequest assessRequest) {
-      List<ListEntity> listEntityList = assessRequest.getSessionData().getListEntity();
-      for (ListEntity listEntity : listEntityList) {
-         List<Entity> entityList = listEntity.getEntity();
-         for(Entity entity : entityList) {
-            List<AttributeOutcome> attributes = entity.getAttributeOutcome();
-            for (AttributeOutcome attributeOutcome : attributes) {
-               if(attributeOutcome.getId().equals("MEANS_CALCULATIONS")) {
-                  return true;
-               }
-            }
-         }
-      }
-      return false;
-   }
+    }
+    return false;
+  }
 
 }

--- a/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/endpoint/ServerPasswordCallback.java
+++ b/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/endpoint/ServerPasswordCallback.java
@@ -1,11 +1,9 @@
 package uk.gov.justice.laa.ccms.endpoint;
 
 import java.io.IOException;
-
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.UnsupportedCallbackException;
-
 import org.apache.wss4j.common.ext.WSPasswordCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,17 +13,17 @@ import org.springframework.stereotype.Component;
 @Component
 public class ServerPasswordCallback implements CallbackHandler {
 
-   @Value("${server.opa10Assess.security.user.password}")
-   private String password;
-   
-   private static final Logger logger = LoggerFactory.getLogger(ServerPasswordCallback.class);
+  @Value("${server.opa10Assess.security.user.password}")
+  private String password;
 
-   @Override
-   public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-      logger.info("password:" + password);
-      for (int i = 0; i < callbacks.length; i++) {
-         WSPasswordCallback pc = (WSPasswordCallback) callbacks[i];
-         pc.setPassword(password);
-      }
-   }
+  private static final Logger logger = LoggerFactory.getLogger(ServerPasswordCallback.class);
+
+  @Override
+  public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+    logger.info("password:" + password);
+    for (int i = 0; i < callbacks.length; i++) {
+      WSPasswordCallback pc = (WSPasswordCallback) callbacks[i];
+      pc.setPassword(password);
+    }
+  }
 }

--- a/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/mapper/AssessRequestMapper.java
+++ b/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/mapper/AssessRequestMapper.java
@@ -1,13 +1,5 @@
 package uk.gov.justice.laa.ccms.mapper;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.mapstruct.AfterMapping;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.MappingTarget;
-
 import com.oracle.determinations.server._10_0.rulebase.types.Attribute;
 import com.oracle.determinations.server._10_0.rulebase.types.AttributeDecisionNode;
 import com.oracle.determinations.server._10_0.rulebase.types.AttributeOutcome;
@@ -32,124 +24,133 @@ import com.oracle.determinations.server._12_2.rulebase.assess.types.Relationship
 import com.oracle.determinations.server._12_2.rulebase.assess.types.RelationshipType;
 import com.oracle.determinations.server._12_2.rulebase.assess.types.UncertainValue;
 import com.oracle.determinations.server._12_2.rulebase.assess.types.UnknownValue;
+import java.util.ArrayList;
+import java.util.List;
+import org.mapstruct.AfterMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 
 @Mapper(componentModel = "spring")
 public interface AssessRequestMapper {
 
-   @Mapping(target = "hypotheticalInstance", ignore = true)
-   @Mapping(target = "instanceId", ignore = true)
-   @Mapping(target = "inferred", ignore = true)
-   @Mapping(target = "relationshipNodeOrAttributeNodeOrAlreadyProvenNode", source = "attributeDecisionNodeOrRelationshipDecisionNode")
-   AttributeNodeType map(AttributeDecisionNode attributeDecisionNode);
+  @Mapping(target = "hypotheticalInstance", ignore = true)
+  @Mapping(target = "instanceId", ignore = true)
+  @Mapping(target = "inferred", ignore = true)
+  @Mapping(target = "relationshipNodeOrAttributeNodeOrAlreadyProvenNode", source = "attributeDecisionNodeOrRelationshipDecisionNode")
+  AttributeNodeType map(AttributeDecisionNode attributeDecisionNode);
 
-   @Mapping(target = "booleanVal", ignore = true)
-   @Mapping(target = "dateVal", ignore = true)
-   @Mapping(target = "datetimeVal", ignore = true)
-   @Mapping(target = "decisionReport", ignore = true)
-   @Mapping(target = "inferred", ignore = true)
-   @Mapping(target = "numberVal", ignore = true)
-   @Mapping(target = "properties", ignore = true)
-   @Mapping(target = "textVal", ignore = true)
-   @Mapping(target = "type", ignore = true)
-   @Mapping(target = "uncertainVal", ignore = true)
-   @Mapping(target = "unknownVal", ignore = true)
-   @Mapping(target = "changePoint", ignore = true)
-   @Mapping(target = "timeVal", ignore = true)
-   AttributeType map(AttributeOutcome attributeOutcome);
+  @Mapping(target = "booleanVal", ignore = true)
+  @Mapping(target = "dateVal", ignore = true)
+  @Mapping(target = "datetimeVal", ignore = true)
+  @Mapping(target = "decisionReport", ignore = true)
+  @Mapping(target = "inferred", ignore = true)
+  @Mapping(target = "numberVal", ignore = true)
+  @Mapping(target = "properties", ignore = true)
+  @Mapping(target = "textVal", ignore = true)
+  @Mapping(target = "type", ignore = true)
+  @Mapping(target = "uncertainVal", ignore = true)
+  @Mapping(target = "unknownVal", ignore = true)
+  @Mapping(target = "changePoint", ignore = true)
+  @Mapping(target = "timeVal", ignore = true)
+  AttributeType map(AttributeOutcome attributeOutcome);
 
-   @Mapping(target = "hypotheticalInstance", ignore = true)
-   @Mapping(target = "inferred", ignore = true)
-   @Mapping(target = "startRelevance", ignore = true)
-   @Mapping(target = "endRelevance", ignore = true)
-   @Mapping(target = "sourceEntityId", ignore = true)
-   @Mapping(target = "targetEntityId", ignore = true)
-   @Mapping(target = "relationshipId", source = "relationshipName")
-   @Mapping(target = "relationshipNodeOrAttributeNodeOrAlreadyProvenNode", source = "attributeDecisionNodeOrRelationshipDecisionNode")
-   @Mapping(target = "sourceInstanceId", source = "source")
-   RelationshipNodeType map(RelationshipDecisionNode relationshipDecisionNode);
+  @Mapping(target = "hypotheticalInstance", ignore = true)
+  @Mapping(target = "inferred", ignore = true)
+  @Mapping(target = "startRelevance", ignore = true)
+  @Mapping(target = "endRelevance", ignore = true)
+  @Mapping(target = "sourceEntityId", ignore = true)
+  @Mapping(target = "targetEntityId", ignore = true)
+  @Mapping(target = "relationshipId", source = "relationshipName")
+  @Mapping(target = "relationshipNodeOrAttributeNodeOrAlreadyProvenNode", source = "attributeDecisionNodeOrRelationshipDecisionNode")
+  @Mapping(target = "sourceInstanceId", source = "source")
+  RelationshipNodeType map(RelationshipDecisionNode relationshipDecisionNode);
 
-   @Mapping(target = "relationshipNodeOrAttributeNodeOrAlreadyProvenNode", source = "relationshipDecisionNodeOrAttributeDecisionNode")
-   DecisionReportType map(DecisionReport decisionReport);
+  @Mapping(target = "relationshipNodeOrAttributeNodeOrAlreadyProvenNode", source = "relationshipDecisionNodeOrAttributeDecisionNode")
+  DecisionReportType map(DecisionReport decisionReport);
 
-   @Mapping(target = "knownOutcomeStyle", ignore = true)
-   @Mapping(target = "outcomeStyle", ignore = true)
-   @Mapping(target = "unknownOutcomeStyle", ignore = true)
-   @Mapping(target = "id", source = "name")
-   RelationshipType map(Relationship relationship);
+  @Mapping(target = "knownOutcomeStyle", ignore = true)
+  @Mapping(target = "outcomeStyle", ignore = true)
+  @Mapping(target = "unknownOutcomeStyle", ignore = true)
+  @Mapping(target = "id", source = "name")
+  RelationshipType map(Relationship relationship);
 
-   @Mapping(target = "instanceId", source = "entityId")
-   RelationshipTargetType map(RelationshipTarget relationshipTarget);
+  @Mapping(target = "instanceId", source = "entityId")
+  RelationshipTargetType map(RelationshipTarget relationshipTarget);
 
-   @Mapping(target = "knownOutcomeStyle", ignore = true)
-   @Mapping(target = "outcomeStyle", ignore = true)
-   @Mapping(target = "unknownOutcomeStyle", ignore = true)
-   @Mapping(target = "inferred", ignore = true)
-   AttributeType map(Attribute attribute);
+  @Mapping(target = "knownOutcomeStyle", ignore = true)
+  @Mapping(target = "outcomeStyle", ignore = true)
+  @Mapping(target = "unknownOutcomeStyle", ignore = true)
+  @Mapping(target = "inferred", ignore = true)
+  AttributeType map(Attribute attribute);
 
-   List<AttributeType> map(List<Attribute> attributes);
+  List<AttributeType> map(List<Attribute> attributes);
 
-   @Mapping(target = "entity", ignore = true)
-   @Mapping(target = "relationship", ignore = true)
-   EntityInstanceType map(Entity entity);
+  @Mapping(target = "entity", ignore = true)
+  @Mapping(target = "relationship", ignore = true)
+  EntityInstanceType map(Entity entity);
 
-   @Mapping(target = "instance", source = "entity")
-   @Mapping(target = "id", source = "entityType")
-   @Mapping(target = "properties", ignore = true)
-   @Mapping(target = "inferred", ignore = true)
-   EntityType map(ListEntity listEntity);
+  @Mapping(target = "instance", source = "entity")
+  @Mapping(target = "id", source = "entityType")
+  @Mapping(target = "properties", ignore = true)
+  @Mapping(target = "inferred", ignore = true)
+  EntityType map(ListEntity listEntity);
 
-   @Mapping(target = "properties", ignore = true)
-   @Mapping(target = "attribute", ignore = true)
-   @Mapping(target = "relationship", ignore = true)
-   @Mapping(target = "entity", source = "listEntity")
-   GlobalInstanceType map(Session session);
+  @Mapping(target = "properties", ignore = true)
+  @Mapping(target = "attribute", ignore = true)
+  @Mapping(target = "relationship", ignore = true)
+  @Mapping(target = "entity", source = "listEntity")
+  GlobalInstanceType map(Session session);
 
-   UncertainValue map(com.oracle.determinations.server._10_0.rulebase.types.UncertainValue value);
+  UncertainValue map(com.oracle.determinations.server._10_0.rulebase.types.UncertainValue value);
 
-   UnknownValue map(com.oracle.determinations.server._10_0.rulebase.types.UnknownValue value);
+  UnknownValue map(com.oracle.determinations.server._10_0.rulebase.types.UnknownValue value);
 
-   @Mapping(target = "outcome", ignore = true)
-   @Mapping(target = "showVersion", ignore = true)
-   AssessmentConfiguration map(com.oracle.determinations.server._10_0.rulebase.types.AssessmentConfiguration assessmentConfiguration);
+  @Mapping(target = "outcome", ignore = true)
+  @Mapping(target = "showVersion", ignore = true)
+  AssessmentConfiguration map(
+      com.oracle.determinations.server._10_0.rulebase.types.AssessmentConfiguration assessmentConfiguration);
 
-   @Mapping(target = "globalInstance", source = "sessionData")
-   AssessRequest map(com.oracle.determinations.server._10_0.rulebase.types.AssessRequest assessRequest);
-   
-   @AfterMapping
-   default void addOutcomeAttribute(@MappingTarget EntityInstanceType entityInstanceType, Entity entity) {
-      for (AttributeOutcome attributeOutcome : entity.getAttributeOutcome()) {
-         entityInstanceType.getAttribute().add(map(attributeOutcome));
+  @Mapping(target = "globalInstance", source = "sessionData")
+  AssessRequest map(
+      com.oracle.determinations.server._10_0.rulebase.types.AssessRequest assessRequest);
+
+  @AfterMapping
+  default void addOutcomeAttribute(@MappingTarget EntityInstanceType entityInstanceType,
+      Entity entity) {
+    for (AttributeOutcome attributeOutcome : entity.getAttributeOutcome()) {
+      entityInstanceType.getAttribute().add(map(attributeOutcome));
+    }
+  }
+
+  default List<Object> mapObjects(List<Object> objects) {
+    List<Object> returnObjects = new ArrayList<Object>();
+
+    for (Object object : objects) {
+      if (object instanceof AttributeDecisionNode) {
+        returnObjects.add(map((AttributeDecisionNode) object));
+      } else if (object instanceof RelationshipDecisionNode) {
+        returnObjects.add(map((RelationshipDecisionNode) object));
+      } else if (object instanceof AlreadyProvenNodeType) {
+        // ignore as there is no corresponding object in the opa10 response
+      } else {
+        returnObjects.add(object);
       }
-   }
+    }
+    return returnObjects;
+  }
 
-   default List<Object> mapObjects(List<Object> objects) {
-      List<Object> returnObjects = new ArrayList<Object>();
+  default List<RelationshipTargetType> map(String target) {
 
-      for (Object object : objects) {
-         if (object instanceof AttributeDecisionNode) {
-            returnObjects.add(map((AttributeDecisionNode) object));
-         } else if (object instanceof RelationshipDecisionNode) {
-            returnObjects.add(map((RelationshipDecisionNode) object));
-         } else if (object instanceof AlreadyProvenNodeType) {
-            // ignore as there is no corresponding object in the opa10 response
-         } else {
-            returnObjects.add(object);
-         }
-      }
-      return returnObjects;
-   }
+    if (target == null) {
+      return null;
+    }
 
-   default List<RelationshipTargetType> map(String target) {
+    List<RelationshipTargetType> relationshipTargetTypes = new ArrayList<RelationshipTargetType>();
 
-      if (target == null) {
-         return null;
-      }
-
-      List<RelationshipTargetType> relationshipTargetTypes = new ArrayList<RelationshipTargetType>();
-
-      RelationshipTargetType relationshipTargetType = new RelationshipTargetType();
-      relationshipTargetType.setInstanceId(target);
-      relationshipTargetTypes.add(relationshipTargetType);
-      return relationshipTargetTypes;
-   }
+    RelationshipTargetType relationshipTargetType = new RelationshipTargetType();
+    relationshipTargetType.setInstanceId(target);
+    relationshipTargetTypes.add(relationshipTargetType);
+    return relationshipTargetTypes;
+  }
 }

--- a/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/mapper/AssessResponseMapper.java
+++ b/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/mapper/AssessResponseMapper.java
@@ -1,11 +1,5 @@
 package uk.gov.justice.laa.ccms.mapper;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-
 import com.oracle.determinations.server._10_0.rulebase.types.AssessResponse;
 import com.oracle.determinations.server._10_0.rulebase.types.Attribute;
 import com.oracle.determinations.server._10_0.rulebase.types.AttributeDecisionNode;
@@ -29,74 +23,80 @@ import com.oracle.determinations.server._12_2.rulebase.assess.types.Relationship
 import com.oracle.determinations.server._12_2.rulebase.assess.types.RelationshipType;
 import com.oracle.determinations.server._12_2.rulebase.assess.types.UncertainValue;
 import com.oracle.determinations.server._12_2.rulebase.assess.types.UnknownValue;
+import java.util.ArrayList;
+import java.util.List;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface AssessResponseMapper {
 
-   @Mapping(target = "alreadyProven", ignore = true)
-   @Mapping(target = "entityType", ignore = true)
-   @Mapping(target = "inferencingType", expression = "java(com.oracle.determinations.server._10_0.rulebase.types.InferencingTypeEnum.GOAL)") 
-   @Mapping(target = "attributeDecisionNodeOrRelationshipDecisionNode", source = "relationshipNodeOrAttributeNodeOrAlreadyProvenNode")
-   AttributeDecisionNode map(AttributeNodeType attributeDecisionNode);
+  @Mapping(target = "alreadyProven", ignore = true)
+  @Mapping(target = "entityType", ignore = true)
+  @Mapping(target = "inferencingType", expression = "java(com.oracle.determinations.server._10_0.rulebase.types.InferencingTypeEnum.GOAL)")
+  @Mapping(target = "attributeDecisionNodeOrRelationshipDecisionNode", source = "relationshipNodeOrAttributeNodeOrAlreadyProvenNode")
+  AttributeDecisionNode map(AttributeNodeType attributeDecisionNode);
 
-   @Mapping(target = "alreadyProven", ignore = true)
-   @Mapping(target = "source", source = "sourceInstanceId")
-   @Mapping(target = "relationshipName", source = "relationshipId")
-   @Mapping(target = "attributeDecisionNodeOrRelationshipDecisionNode", source = "relationshipNodeOrAttributeNodeOrAlreadyProvenNode")
-   @Mapping(target = "target", ignore = true)
-   RelationshipDecisionNode map(RelationshipNodeType relationshipNodeType);
+  @Mapping(target = "alreadyProven", ignore = true)
+  @Mapping(target = "source", source = "sourceInstanceId")
+  @Mapping(target = "relationshipName", source = "relationshipId")
+  @Mapping(target = "attributeDecisionNodeOrRelationshipDecisionNode", source = "relationshipNodeOrAttributeNodeOrAlreadyProvenNode")
+  @Mapping(target = "target", ignore = true)
+  RelationshipDecisionNode map(RelationshipNodeType relationshipNodeType);
 
-   @Mapping(target = "outcomeId", ignore = true)
-   @Mapping(target = "relationshipDecisionNodeOrAttributeDecisionNode", source = "relationshipNodeOrAttributeNodeOrAlreadyProvenNode")
-   DecisionReport map(DecisionReportType decisionReportType);
+  @Mapping(target = "outcomeId", ignore = true)
+  @Mapping(target = "relationshipDecisionNodeOrAttributeDecisionNode", source = "relationshipNodeOrAttributeNodeOrAlreadyProvenNode")
+  DecisionReport map(DecisionReportType decisionReportType);
 
-   @Mapping(target = "name", source = "id")
-   Relationship map(RelationshipType relationship);
+  @Mapping(target = "name", source = "id")
+  Relationship map(RelationshipType relationship);
 
-   @Mapping(target = "entityId", source = "instanceId")
-   RelationshipTarget map(RelationshipTargetType relationshipTargetType);
+  @Mapping(target = "entityId", source = "instanceId")
+  RelationshipTarget map(RelationshipTargetType relationshipTargetType);
 
-   @Mapping(target = "userData", ignore = true)
-   @Mapping(target = "screen", ignore = true)
-   @Mapping(target = "inferencingType", expression = "java(com.oracle.determinations.server._10_0.rulebase.types.InferencingTypeEnum.GOAL)") 
-   Attribute map(AttributeType attribute);
+  @Mapping(target = "userData", ignore = true)
+  @Mapping(target = "screen", ignore = true)
+  @Mapping(target = "inferencingType", expression = "java(com.oracle.determinations.server._10_0.rulebase.types.InferencingTypeEnum.GOAL)")
+  Attribute map(AttributeType attribute);
 
-   @Mapping(target = "properties", ignore = true)
-   @Mapping(target = "attributeOutcome", ignore = true)
-   @Mapping(target = "relationships.relationship", source = "relationship")
-   Entity map(EntityInstanceType entity);
+  @Mapping(target = "properties", ignore = true)
+  @Mapping(target = "attributeOutcome", ignore = true)
+  @Mapping(target = "relationships.relationship", source = "relationship")
+  Entity map(EntityInstanceType entity);
 
-   @Mapping(target = "collected", ignore = true)
-   @Mapping(target = "entity", source = "instance")
-   @Mapping(target = "entityType", source = "id")
-   ListEntity map(EntityType listEntity);
+  @Mapping(target = "collected", ignore = true)
+  @Mapping(target = "entity", source = "instance")
+  @Mapping(target = "entityType", source = "id")
+  ListEntity map(EntityType listEntity);
 
-   com.oracle.determinations.server._10_0.rulebase.types.UncertainValue map(UncertainValue value);
+  com.oracle.determinations.server._10_0.rulebase.types.UncertainValue map(UncertainValue value);
 
-   com.oracle.determinations.server._10_0.rulebase.types.UnknownValue map(UnknownValue value);
+  com.oracle.determinations.server._10_0.rulebase.types.UnknownValue map(UnknownValue value);
 
-   @Mapping(target = "listEntity", source = "entity")
-   Session map(GlobalInstanceType session);
+  @Mapping(target = "listEntity", source = "entity")
+  Session map(GlobalInstanceType session);
 
-   com.oracle.determinations.server._10_0.rulebase.types.AssessmentConfiguration map(AssessmentConfiguration assessmentConfiguration);
+  com.oracle.determinations.server._10_0.rulebase.types.AssessmentConfiguration map(
+      AssessmentConfiguration assessmentConfiguration);
 
-   @Mapping(target = "sessionData", source = "globalInstance")
-   AssessResponse map(com.oracle.determinations.server._12_2.rulebase.assess.types.AssessResponse assessResponse);
-   
-   default List<Object> mapObjects(List<Object> objects) {
-      List<Object> returnObjects = new ArrayList<Object>();
+  @Mapping(target = "sessionData", source = "globalInstance")
+  AssessResponse map(
+      com.oracle.determinations.server._12_2.rulebase.assess.types.AssessResponse assessResponse);
 
-      for (Object object : objects) {
-         if (object instanceof AttributeNodeType) {
-            returnObjects.add(map((AttributeNodeType) object));
-         } else if (object instanceof RelationshipNodeType) {
-            returnObjects.add(map((RelationshipNodeType) object));
-         } else if (object instanceof AlreadyProvenNodeType) {
-            // ignore as there is no corresponding object in the opa10 response
-         } else {
-            returnObjects.add(object);
-         }
+  default List<Object> mapObjects(List<Object> objects) {
+    List<Object> returnObjects = new ArrayList<Object>();
+
+    for (Object object : objects) {
+      if (object instanceof AttributeNodeType) {
+        returnObjects.add(map((AttributeNodeType) object));
+      } else if (object instanceof RelationshipNodeType) {
+        returnObjects.add(map((RelationshipNodeType) object));
+      } else if (object instanceof AlreadyProvenNodeType) {
+        // ignore as there is no corresponding object in the opa10 response
+      } else {
+        returnObjects.add(object);
       }
-      return returnObjects;
-   }
+    }
+    return returnObjects;
+  }
 }

--- a/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/mapper/EntityLevelRelocationService.java
+++ b/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/mapper/EntityLevelRelocationService.java
@@ -5,15 +5,17 @@ import com.oracle.determinations.server._12_2.rulebase.assess.types.AssessRespon
 
 public interface EntityLevelRelocationService {
 
-   String getGlobalEntityId(com.oracle.determinations.server._10_0.rulebase.types.AssessRequest request);
+  String getGlobalEntityId(
+      com.oracle.determinations.server._10_0.rulebase.types.AssessRequest request);
 
-   void moveGlobalAttributesAndRelationsToBaseLevel(AssessRequest request);
-   
-   void moveSubEntitiesToLowerLevel(AssessRequest request);
+  void moveGlobalAttributesAndRelationsToBaseLevel(AssessRequest request);
 
-   void moveGlobalEntityToLowerLevel(AssessResponse response, String globalEntityId);
-   
-   void moveSubEntitiesToUpperLevel(AssessResponse response);
-   
-   void mapOpa10Relationships(com.oracle.determinations.server._10_0.rulebase.types.AssessResponse response);
+  void moveSubEntitiesToLowerLevel(AssessRequest request);
+
+  void moveGlobalEntityToLowerLevel(AssessResponse response, String globalEntityId);
+
+  void moveSubEntitiesToUpperLevel(AssessResponse response);
+
+  void mapOpa10Relationships(
+      com.oracle.determinations.server._10_0.rulebase.types.AssessResponse response);
 }

--- a/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/mapper/EntityLevelRelocationServiceImpl.java
+++ b/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/mapper/EntityLevelRelocationServiceImpl.java
@@ -1,12 +1,5 @@
 package uk.gov.justice.laa.ccms.mapper;
 
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
-
 import com.google.common.collect.ImmutableMap;
 import com.oracle.determinations.server._10_0.rulebase.types.Entity;
 import com.oracle.determinations.server._10_0.rulebase.types.ListEntity;
@@ -17,129 +10,142 @@ import com.oracle.determinations.server._12_2.rulebase.assess.types.AssessRespon
 import com.oracle.determinations.server._12_2.rulebase.assess.types.AttributeType;
 import com.oracle.determinations.server._12_2.rulebase.assess.types.EntityInstanceType;
 import com.oracle.determinations.server._12_2.rulebase.assess.types.EntityType;
-
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.ccms.service.OPAEntity;
 
 @Component
 public class EntityLevelRelocationServiceImpl implements EntityLevelRelocationService {
 
-	@Autowired
-	private Map<String, OPAEntity> opaEntities;
+  @Autowired
+  private Map<String, OPAEntity> opaEntities;
 
-	private static final Map<String, String> SUBENTITY_MAP = ImmutableMap.<String, String>builder()
-			.put("ADDTHIRD", "ADDPROPERTY").put("BPFAMILYEMPL", "BUSINESSPART").put("BPPROPERTY", "BUSINESSPART")
-			.put("BUSPARTBANK", "BUSINESSPART").put("CLI_NON_HM_L17", "EMPLOYMENT_CLIENT")
-			.put("CLI_NON_HM_WAGE_SLIP", "EMPLOYMENT_CLIENT").put("COPROPERTY", "COMPANY")
-			.put("EMPLOY_BEN_CLIENT", "EMPLOYMENT_CLIENT").put("EMPLOY_BEN_PARTNER", "EMPLOYMENT_PARTNER")
-			.put("EMP_CLI_KNOWN_CHANGE", "EMPLOYMENT_CLIENT").put("PAR_EMPLOY_KNOWN_CHANGE", "EMPLOYMENT_PARTNER")
-			.put("PAR_NON_HM_L17", "EMPLOYMENT_PARTNER").put("PAR_NON_HM_WAGE_SLIP", "EMPLOYMENT_PARTNER")
-			.put("SEFAMILYEMPL", "SELFEMPLOY").put("SELFEMPBANK", "SELFEMPLOY").put("SEPROPERTY", "SELFEMPLOY")
-			.put("SHARE", "COMPANY").build();
+  private static final Map<String, String> SUBENTITY_MAP = ImmutableMap.<String, String>builder()
+      .put("ADDTHIRD", "ADDPROPERTY").put("BPFAMILYEMPL", "BUSINESSPART")
+      .put("BPPROPERTY", "BUSINESSPART")
+      .put("BUSPARTBANK", "BUSINESSPART").put("CLI_NON_HM_L17", "EMPLOYMENT_CLIENT")
+      .put("CLI_NON_HM_WAGE_SLIP", "EMPLOYMENT_CLIENT").put("COPROPERTY", "COMPANY")
+      .put("EMPLOY_BEN_CLIENT", "EMPLOYMENT_CLIENT").put("EMPLOY_BEN_PARTNER", "EMPLOYMENT_PARTNER")
+      .put("EMP_CLI_KNOWN_CHANGE", "EMPLOYMENT_CLIENT")
+      .put("PAR_EMPLOY_KNOWN_CHANGE", "EMPLOYMENT_PARTNER")
+      .put("PAR_NON_HM_L17", "EMPLOYMENT_PARTNER").put("PAR_NON_HM_WAGE_SLIP", "EMPLOYMENT_PARTNER")
+      .put("SEFAMILYEMPL", "SELFEMPLOY").put("SELFEMPBANK", "SELFEMPLOY")
+      .put("SEPROPERTY", "SELFEMPLOY")
+      .put("SHARE", "COMPANY").build();
 
-	@Override
-	public String getGlobalEntityId(com.oracle.determinations.server._10_0.rulebase.types.AssessRequest request) {
-		return request.getSessionData().getListEntity().stream()
-				.filter(entity -> entity.getEntityType().equalsIgnoreCase("global")).findFirst()
-				.map(e -> e.getEntity().get(0).getId()).get();
+  @Override
+  public String getGlobalEntityId(
+      com.oracle.determinations.server._10_0.rulebase.types.AssessRequest request) {
+    return request.getSessionData().getListEntity().stream()
+        .filter(entity -> entity.getEntityType().equalsIgnoreCase("global")).findFirst()
+        .map(e -> e.getEntity().get(0).getId()).get();
 
-	}
+  }
 
-	@Override
-	public void moveGlobalAttributesAndRelationsToBaseLevel(AssessRequest request) {
-		List<AttributeType> attributeTypes = request.getGlobalInstance().getEntity().stream()
-				.filter(entity -> entity.getId().equalsIgnoreCase("global")).map(entity -> entity.getInstance())
-				.flatMap(el -> el.stream()).map(e -> e.getAttribute()).flatMap(al -> al.stream())
-				.collect(Collectors.toList());
+  @Override
+  public void moveGlobalAttributesAndRelationsToBaseLevel(AssessRequest request) {
+    List<AttributeType> attributeTypes = request.getGlobalInstance().getEntity().stream()
+        .filter(entity -> entity.getId().equalsIgnoreCase("global"))
+        .map(entity -> entity.getInstance())
+        .flatMap(el -> el.stream()).map(e -> e.getAttribute()).flatMap(al -> al.stream())
+        .collect(Collectors.toList());
 
-		request.getGlobalInstance().getAttribute().addAll(attributeTypes);
+    request.getGlobalInstance().getAttribute().addAll(attributeTypes);
 
-		request.getGlobalInstance().getEntity().removeIf(list -> list.getId().equalsIgnoreCase("global"));
+    request.getGlobalInstance().getEntity()
+        .removeIf(list -> list.getId().equalsIgnoreCase("global"));
 
-	}
+  }
 
-	@Override
-	public void moveSubEntitiesToLowerLevel(AssessRequest request) {
+  @Override
+  public void moveSubEntitiesToLowerLevel(AssessRequest request) {
 
-		List<EntityType> subEntities = request.getGlobalInstance().getEntity().stream()
-				.filter(entity -> SUBENTITY_MAP.keySet().contains(entity.getId())).collect(Collectors.toList());
-		if (subEntities == null) {
-			return;
-		}
+    List<EntityType> subEntities = request.getGlobalInstance().getEntity().stream()
+        .filter(entity -> SUBENTITY_MAP.containsKey(entity.getId()))
+        .collect(Collectors.toList());
+    if (subEntities == null) {
+      return;
+    }
 
-		for (EntityType subEntity : subEntities) {
-			List<EntityType> parentEntities = request.getGlobalInstance().getEntity().stream()
-					.filter(parent -> SUBENTITY_MAP.get(subEntity.getId()).equals(parent.getId()))
-					.collect(Collectors.toList());
-			if (parentEntities.size() != 1) {
-				throw new IllegalStateException();
-			}
+    for (EntityType subEntity : subEntities) {
+      List<EntityType> parentEntities = request.getGlobalInstance().getEntity().stream()
+          .filter(parent -> SUBENTITY_MAP.get(subEntity.getId()).equals(parent.getId()))
+          .collect(Collectors.toList());
+      if (parentEntities.size() != 1) {
+        throw new IllegalStateException();
+      }
 
-			parentEntities.get(0).getInstance().get(0).getEntity().add(subEntity);
-		}
+      parentEntities.get(0).getInstance().get(0).getEntity().add(subEntity);
+    }
 
-		request.getGlobalInstance().getEntity().removeIf(entity -> subEntities.contains(entity));
-	}
+    request.getGlobalInstance().getEntity().removeIf(entity -> subEntities.contains(entity));
+  }
 
-	@Override
-	public void moveGlobalEntityToLowerLevel(AssessResponse response, String globalEntityId) {
+  @Override
+  public void moveGlobalEntityToLowerLevel(AssessResponse response, String globalEntityId) {
 
-		EntityType entityType = new EntityType();
-		entityType.setId("global");
-		EntityInstanceType entityInstanceType = new EntityInstanceType();
-		entityInstanceType.setId(globalEntityId);
-		entityInstanceType.getAttribute().addAll(response.getGlobalInstance().getAttribute());
-		entityInstanceType.getRelationship().addAll(response.getGlobalInstance().getRelationship());
+    EntityType entityType = new EntityType();
+    entityType.setId("global");
+    EntityInstanceType entityInstanceType = new EntityInstanceType();
+    entityInstanceType.setId(globalEntityId);
+    entityInstanceType.getAttribute().addAll(response.getGlobalInstance().getAttribute());
+    entityInstanceType.getRelationship().addAll(response.getGlobalInstance().getRelationship());
 
-		entityType.getInstance().add(entityInstanceType);
+    entityType.getInstance().add(entityInstanceType);
 
-		response.getGlobalInstance().getEntity().add(entityType);
-	}
+    response.getGlobalInstance().getEntity().add(entityType);
+  }
 
-	@Override
-	public void moveSubEntitiesToUpperLevel(AssessResponse response) {
+  @Override
+  public void moveSubEntitiesToUpperLevel(AssessResponse response) {
 
-		List<EntityType> nestedEntities = response.getGlobalInstance().getEntity().stream()
-				.map(entityType -> entityType.getInstance()).flatMap(el -> el.stream())
-				.map(entityInstanceType -> entityInstanceType.getEntity())
-				.flatMap(entityTypeList -> entityTypeList.stream()).collect(Collectors.toList());
+    List<EntityType> nestedEntities = response.getGlobalInstance().getEntity().stream()
+        .map(entityType -> entityType.getInstance()).flatMap(el -> el.stream())
+        .map(entityInstanceType -> entityInstanceType.getEntity())
+        .flatMap(entityTypeList -> entityTypeList.stream()).collect(Collectors.toList());
 
-		response.getGlobalInstance().getEntity().addAll(nestedEntities);
+    response.getGlobalInstance().getEntity().addAll(nestedEntities);
 
-		// we do not need to remove these from nested level as the mapstruct mapping
-		// takes care for this
+    // we do not need to remove these from nested level as the mapstruct mapping
+    // takes care for this
 
-	}
+  }
 
-	public void mapOpa10Relationships(com.oracle.determinations.server._10_0.rulebase.types.AssessResponse response) {
-		List<ListEntity> listEntities = response.getSessionData().getListEntity().stream()
-				.filter(en -> !en.getEntityType().equalsIgnoreCase("global")).collect(Collectors.toList());
+  public void mapOpa10Relationships(
+      com.oracle.determinations.server._10_0.rulebase.types.AssessResponse response) {
+    List<ListEntity> listEntities = response.getSessionData().getListEntity().stream()
+        .filter(en -> !en.getEntityType().equalsIgnoreCase("global")).collect(Collectors.toList());
 
-		for (ListEntity listEntity : listEntities) {
+    for (ListEntity listEntity : listEntities) {
 
-			OPAEntity opaEntity = opaEntities.get(listEntity.getEntityType());
+      OPAEntity opaEntity = opaEntities.get(listEntity.getEntityType());
 
-			ListEntity parentEntity = response.getSessionData().getListEntity().stream()
-					.filter(en -> en.getEntityType().equalsIgnoreCase(opaEntity.getParentEntityCode())).findFirst()
-					.get();
+      ListEntity parentEntity = response.getSessionData().getListEntity().stream()
+          .filter(en -> en.getEntityType().equalsIgnoreCase(opaEntity.getParentEntityCode()))
+          .findFirst()
+          .get();
 
-			Relationship parentRelationship = new Relationship();
-			parentRelationship.setName(opaEntity.getRelationshipPublicName());
+      Relationship parentRelationship = new Relationship();
+      parentRelationship.setName(opaEntity.getRelationshipPublicName());
 
-			for (Entity entity : listEntity.getEntity()) {
-				RelationshipTarget parentTarget = new RelationshipTarget();
-				parentTarget.setEntityId(entity.getId());
-				parentRelationship.getTarget().add(parentTarget);
+      for (Entity entity : listEntity.getEntity()) {
+        RelationshipTarget parentTarget = new RelationshipTarget();
+        parentTarget.setEntityId(entity.getId());
+        parentRelationship.getTarget().add(parentTarget);
 
-				Relationship childRelationship = new Relationship();
-				childRelationship.setName(opaEntity.getReverseRelPublicName());
-				RelationshipTarget target = new RelationshipTarget();
-				target.setEntityId(parentEntity.getEntity().get(0).getId());
-				childRelationship.getTarget().add(target);
+        Relationship childRelationship = new Relationship();
+        childRelationship.setName(opaEntity.getReverseRelPublicName());
+        RelationshipTarget target = new RelationshipTarget();
+        target.setEntityId(parentEntity.getEntity().get(0).getId());
+        childRelationship.getTarget().add(target);
 
-				entity.getRelationships().getRelationship().add(childRelationship);
-			}
-			parentEntity.getEntity().get(0).getRelationships().getRelationship().add(parentRelationship);
+        entity.getRelationships().getRelationship().add(childRelationship);
+      }
+      parentEntity.getEntity().get(0).getRelationships().getRelationship().add(parentRelationship);
 
-		}
-	}
+    }
+  }
 }

--- a/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/service/OPAEntity.java
+++ b/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/service/OPAEntity.java
@@ -2,62 +2,77 @@ package uk.gov.justice.laa.ccms.service;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
-@JsonPropertyOrder(value = { "lookupcode", "entityCode", "entityLevel","parentEntityCode","relationshipPublicName","reverseRelPublicName"})
+@JsonPropertyOrder(value = {"lookupcode", "entityCode", "entityLevel", "parentEntityCode",
+    "relationshipPublicName", "reverseRelPublicName"})
 public class OPAEntity {
-	
-	private String lookupcode;
-	private String  entityCode;
-	private Integer entityLevel;
-	private String parentEntityCode;
-	private String relationshipPublicName;
-	private String reverseRelPublicName;
-	
-	public OPAEntity() {}
-	
-	public OPAEntity(String lookupcode, String entityCode, Integer entityLevel, String parentEntityCode,
-			String relationshipPublicName, String reverseRelPublicName) {
-		super();
-		this.lookupcode = lookupcode;
-		this.entityCode = entityCode;
-		this.entityLevel = entityLevel;
-		this.parentEntityCode = parentEntityCode;
-		this.relationshipPublicName = relationshipPublicName;
-		this.reverseRelPublicName = reverseRelPublicName;
-	}
-	public String getLookupcode() {
-		return lookupcode;
-	}
-	public void setLookupcode(String lookupcode) {
-		this.lookupcode = lookupcode;
-	}
-	public String getEntityCode() {
-		return entityCode;
-	}
-	public void setEntityCode(String entityCode) {
-		this.entityCode = entityCode;
-	}
-	public Integer getEntityLevel() {
-		return entityLevel;
-	}
-	public void setEntityLevel(Integer entityLevel) {
-		this.entityLevel = entityLevel;
-	}
-	public String getParentEntityCode() {
-		return parentEntityCode;
-	}
-	public void setParentEntityCode(String parentEntityCode) {
-		this.parentEntityCode = parentEntityCode;
-	}
-	public String getRelationshipPublicName() {
-		return relationshipPublicName;
-	}
-	public void setRelationshipPublicName(String relationshipPublicName) {
-		this.relationshipPublicName = relationshipPublicName;
-	}
-	public String getReverseRelPublicName() {
-		return reverseRelPublicName;
-	}
-	public void setReverseRelPublicName(String reverseRelPublicName) {
-		this.reverseRelPublicName = reverseRelPublicName;
-	}
+
+  private String lookupcode;
+  private String entityCode;
+  private Integer entityLevel;
+  private String parentEntityCode;
+  private String relationshipPublicName;
+  private String reverseRelPublicName;
+
+  public OPAEntity() {
+  }
+
+  public OPAEntity(String lookupcode, String entityCode, Integer entityLevel,
+      String parentEntityCode,
+      String relationshipPublicName, String reverseRelPublicName) {
+    super();
+    this.lookupcode = lookupcode;
+    this.entityCode = entityCode;
+    this.entityLevel = entityLevel;
+    this.parentEntityCode = parentEntityCode;
+    this.relationshipPublicName = relationshipPublicName;
+    this.reverseRelPublicName = reverseRelPublicName;
+  }
+
+  public String getLookupcode() {
+    return lookupcode;
+  }
+
+  public void setLookupcode(String lookupcode) {
+    this.lookupcode = lookupcode;
+  }
+
+  public String getEntityCode() {
+    return entityCode;
+  }
+
+  public void setEntityCode(String entityCode) {
+    this.entityCode = entityCode;
+  }
+
+  public Integer getEntityLevel() {
+    return entityLevel;
+  }
+
+  public void setEntityLevel(Integer entityLevel) {
+    this.entityLevel = entityLevel;
+  }
+
+  public String getParentEntityCode() {
+    return parentEntityCode;
+  }
+
+  public void setParentEntityCode(String parentEntityCode) {
+    this.parentEntityCode = parentEntityCode;
+  }
+
+  public String getRelationshipPublicName() {
+    return relationshipPublicName;
+  }
+
+  public void setRelationshipPublicName(String relationshipPublicName) {
+    this.relationshipPublicName = relationshipPublicName;
+  }
+
+  public String getReverseRelPublicName() {
+    return reverseRelPublicName;
+  }
+
+  public void setReverseRelPublicName(String reverseRelPublicName) {
+    this.reverseRelPublicName = reverseRelPublicName;
+  }
 }

--- a/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/service/ReferenceDataService.java
+++ b/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/service/ReferenceDataService.java
@@ -3,7 +3,6 @@ package uk.gov.justice.laa.ccms.service;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
-import java.io.File;
 import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
@@ -17,27 +16,27 @@ import org.springframework.stereotype.Service;
 @Service
 public class ReferenceDataService {
 
-	private Logger logger = LoggerFactory.getLogger(ReferenceDataService.class);
-	
-	@Autowired
-	private ApplicationContext context;
+  private final Logger logger = LoggerFactory.getLogger(ReferenceDataService.class);
 
-	public <T> List<T> loadObjectList(Class<T> type, String fileName) {
-		try {
-			CsvMapper mapper = new CsvMapper();
-			CsvSchema schema = mapper.schemaFor(type).withSkipFirstDataRow(true).withColumnSeparator(',');
+  @Autowired
+  private ApplicationContext context;
 
-			InputStream resource = new ClassPathResource(
-					fileName).getInputStream();
+  public <T> List<T> loadObjectList(Class<T> type, String fileName) {
+    try {
+      CsvMapper mapper = new CsvMapper();
+      CsvSchema schema = mapper.schemaFor(type).withSkipFirstDataRow(true).withColumnSeparator(',');
 
-			MappingIterator<T> it = mapper.readerFor(type).with(schema)
-					  .readValues(resource);
-	
-			return it.readAll();
-		} catch (Exception e) {
-			logger.error("Error occurred while loading object list from file " + fileName, e);
-			return Collections.emptyList();
-		}
-	}
+      InputStream resource = new ClassPathResource(
+          fileName).getInputStream();
+
+      MappingIterator<T> it = mapper.readerFor(type).with(schema)
+          .readValues(resource);
+
+      return it.readAll();
+    } catch (Exception e) {
+      logger.error("Error occurred while loading object list from file " + fileName, e);
+      return Collections.emptyList();
+    }
+  }
 
 }

--- a/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/soap/client/ClientPasswordCallback.java
+++ b/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/soap/client/ClientPasswordCallback.java
@@ -1,11 +1,9 @@
 package uk.gov.justice.laa.ccms.soap.client;
 
 import java.io.IOException;
-
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.UnsupportedCallbackException;
-
 import org.apache.wss4j.common.ext.WSPasswordCallback;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -13,14 +11,14 @@ import org.springframework.stereotype.Component;
 @Component
 public class ClientPasswordCallback implements CallbackHandler {
 
-   @Value("${client.opa12Assess.security.user.password}")
-   private String password;
+  @Value("${client.opa12Assess.security.user.password}")
+  private String password;
 
-   @Override
-   public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-      for (int i = 0; i < callbacks.length; i++) {
-         WSPasswordCallback pc = (WSPasswordCallback) callbacks[i];
-         pc.setPassword(password);
-      }
-   }
+  @Override
+  public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+    for (int i = 0; i < callbacks.length; i++) {
+      WSPasswordCallback pc = (WSPasswordCallback) callbacks[i];
+      pc.setPassword(password);
+    }
+  }
 }

--- a/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/soap/client/Opa12AssessClientConfig.java
+++ b/opa_10_12_transform/src/main/java/uk/gov/justice/laa/ccms/soap/client/Opa12AssessClientConfig.java
@@ -1,8 +1,8 @@
 package uk.gov.justice.laa.ccms.soap.client;
 
+import com.oracle.determinations.server._12_2.rulebase.assess.types.OdsAssessServiceGeneric122MeansAssessmentV12Type;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.apache.cxf.frontend.ClientProxy;
 import org.apache.cxf.interceptor.LoggingInInterceptor;
 import org.apache.cxf.interceptor.LoggingOutInterceptor;
@@ -17,57 +17,57 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import com.oracle.determinations.server._12_2.rulebase.assess.types.OdsAssessServiceGeneric122MeansAssessmentV12Type;
-
 @SuppressWarnings("deprecation")
 @Configuration
 public class Opa12AssessClientConfig {
-   private static final Logger logger = LoggerFactory.getLogger(Opa12AssessClientConfig.class);
 
-   @Value("${client.opa12Assess.means.address}")
-   private String meansAddress;
+  private static final Logger logger = LoggerFactory.getLogger(Opa12AssessClientConfig.class);
 
-   @Value("${client.opa12Assess.billing.address}")
-   private String billingAddress;
+  @Value("${client.opa12Assess.means.address}")
+  private String meansAddress;
 
-   @Value("${client.opa12Assess.security.user.name}")
-   private String userName;
+  @Value("${client.opa12Assess.billing.address}")
+  private String billingAddress;
 
-   @Autowired
-   private ClientPasswordCallback clientPasswordCallback;
+  @Value("${client.opa12Assess.security.user.name}")
+  private String userName;
 
-   @Bean(name = "opa12MeansAssessServiceProxy")
-   public OdsAssessServiceGeneric122MeansAssessmentV12Type opa12MeansAssessServiceProxy() {
-      return getOdsAssessServiceGeneric122MeansAssessmentV12Type(meansAddress);
-   }
+  @Autowired
+  private ClientPasswordCallback clientPasswordCallback;
 
-   @Bean(name = "opa12BillingAssessServiceProxy")
-   public OdsAssessServiceGeneric122MeansAssessmentV12Type opa12BillingAssessServiceProxy() {
-      return getOdsAssessServiceGeneric122MeansAssessmentV12Type(billingAddress);
-   }
+  @Bean(name = "opa12MeansAssessServiceProxy")
+  public OdsAssessServiceGeneric122MeansAssessmentV12Type opa12MeansAssessServiceProxy() {
+    return getOdsAssessServiceGeneric122MeansAssessmentV12Type(meansAddress);
+  }
 
-   private OdsAssessServiceGeneric122MeansAssessmentV12Type getOdsAssessServiceGeneric122MeansAssessmentV12Type(
-       String address) {
-      logger.debug("Address:" + address);
+  @Bean(name = "opa12BillingAssessServiceProxy")
+  public OdsAssessServiceGeneric122MeansAssessmentV12Type opa12BillingAssessServiceProxy() {
+    return getOdsAssessServiceGeneric122MeansAssessmentV12Type(billingAddress);
+  }
 
-      JaxWsProxyFactoryBean jaxWsProxyFactoryBean = new JaxWsProxyFactoryBean();
-      jaxWsProxyFactoryBean.setServiceClass(OdsAssessServiceGeneric122MeansAssessmentV12Type.class);
-      jaxWsProxyFactoryBean.setAddress(address);
-      jaxWsProxyFactoryBean.getInInterceptors().add(new LoggingInInterceptor());
-      jaxWsProxyFactoryBean.getOutInterceptors().add(new LoggingOutInterceptor());
+  private OdsAssessServiceGeneric122MeansAssessmentV12Type getOdsAssessServiceGeneric122MeansAssessmentV12Type(
+      String address) {
+    logger.debug("Address:" + address);
 
-      OdsAssessServiceGeneric122MeansAssessmentV12Type proxy = (OdsAssessServiceGeneric122MeansAssessmentV12Type) jaxWsProxyFactoryBean.create();
+    JaxWsProxyFactoryBean jaxWsProxyFactoryBean = new JaxWsProxyFactoryBean();
+    jaxWsProxyFactoryBean.setServiceClass(OdsAssessServiceGeneric122MeansAssessmentV12Type.class);
+    jaxWsProxyFactoryBean.setAddress(address);
+    jaxWsProxyFactoryBean.getInInterceptors().add(new LoggingInInterceptor());
+    jaxWsProxyFactoryBean.getOutInterceptors().add(new LoggingOutInterceptor());
 
-      Map<String, Object> outProps = new HashMap<String, Object>();
-      outProps.put(WSHandlerConstants.ACTION, WSConstants.USERNAME_TOKEN_LN);
-      outProps.put(WSHandlerConstants.PASSWORD_TYPE, WSConstants.PW_TEXT);
-      outProps.put(WSHandlerConstants.USER, userName);
-      outProps.put(WSHandlerConstants.PW_CALLBACK_REF, clientPasswordCallback);
+    OdsAssessServiceGeneric122MeansAssessmentV12Type proxy = (OdsAssessServiceGeneric122MeansAssessmentV12Type) jaxWsProxyFactoryBean
+        .create();
 
-      org.apache.cxf.endpoint.Client client = ClientProxy.getClient(proxy);
-      client.getOutInterceptors().add(new WSS4JOutInterceptor(outProps));
-      return proxy;
-   }
+    Map<String, Object> outProps = new HashMap<String, Object>();
+    outProps.put(WSHandlerConstants.ACTION, WSConstants.USERNAME_TOKEN_LN);
+    outProps.put(WSHandlerConstants.PASSWORD_TYPE, WSConstants.PW_TEXT);
+    outProps.put(WSHandlerConstants.USER, userName);
+    outProps.put(WSHandlerConstants.PW_CALLBACK_REF, clientPasswordCallback);
+
+    org.apache.cxf.endpoint.Client client = ClientProxy.getClient(proxy);
+    client.getOutInterceptors().add(new WSS4JOutInterceptor(outProps));
+    return proxy;
+  }
 
 
 }


### PR DESCRIPTION
A lot of the code has inconsistent formatting, for example:

- tabs and spaces for indenting
- different indentation levels

We want to have a single consistent style so the code is easier to read
and it's easier to review stuff without worrying about stylistic things.

To produce this change we ran a "reformat" from IntelliJ on all java
files, using the Google Style Guide formatter from https://github.com/google/styleguide

To review this it might be helpful to change the diff settings to "ignore whitespace" in github.