### PR TITLE
Fix for log4j2 security vulnerability issue in v2.7

### DIFF
--- a/src/main/resources/log4j2-dev.xml
+++ b/src/main/resources/log4j2-dev.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN" monitorInterval="30">
 	<Properties>
-		<Property name="LOG_PATTERN">%d %-5p [%X{msgId}] %c - %m%n</Property>
+		<Property name="LOG_PATTERN">%d %-5p [%X{msgId}] %c - %m{nolookups}%n</Property>
 		<Property name="LOG_DIRECTORY">/app_base/SNDOPB20/Middleware/user_projects/domains/sndopb20_domain/connector_logs</Property>
 		<Property name="LOG_SUFFIX">_civil</Property>
 		<Property name="ERR_FILE_NAME">${LOG_DIRECTORY}/ccms_pui_err${LOG_SUFFIX}.log</Property>

--- a/src/main/resources/log4j2-local.xml
+++ b/src/main/resources/log4j2-local.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN" monitorInterval="30">
 	<Properties>
-		<Property name="LOG_PATTERN">%d %-5p [%X{msgId}] %c - %m%n</Property>
+		<Property name="LOG_PATTERN">%d %-5p [%X{msgId}] %c - %m{nolookups}%n</Property>
 	</Properties>
 	<Appenders>
 		<Console name="stdout" target="SYSTEM_OUT" >

--- a/src/main/resources/log4j2-prod.xml
+++ b/src/main/resources/log4j2-prod.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN" monitorInterval="30">
 	<Properties>
-		<Property name="LOG_PATTERN">%d %-5p [%X{msgId}] %c - %m%n</Property>
+		<Property name="LOG_PATTERN">%d %-5p [%X{msgId}] %c - %m{nolookups}%n</Property>
 		<Property name="LOG_DIRECTORY">/u01/oracle/prod/opa12prod/mid/1213/user_projects/domains/opa12prod_domain/connector-logs</Property>
 		<Property name="LOG_SUFFIX">_civil</Property>
 		<Property name="ERR_FILE_NAME">${LOG_DIRECTORY}/ccms_assess_service_adapter_err${LOG_SUFFIX}.log</Property>

--- a/src/main/resources/log4j2-stage.xml
+++ b/src/main/resources/log4j2-stage.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN" monitorInterval="30">
 	<Properties>
-		<Property name="LOG_PATTERN">%d %-5p [%X{msgId}] %c - %m%n</Property>
+		<Property name="LOG_PATTERN">%d %-5p [%X{msgId}] %c - %m{nolookups}%n</Property>
 		<Property name="LOG_DIRECTORY">/u01/oracle/e10/opa12e10/mid/1213/user_projects/domains/opa12e10_domain/connector-logs</Property>
 		<Property name="LOG_SUFFIX">_civil</Property>
 		<Property name="ERR_FILE_NAME">${LOG_DIRECTORY}/ccms_assess_service_adapter_err${LOG_SUFFIX}.log</Property>

--- a/src/main/resources/log4j2-uat.xml
+++ b/src/main/resources/log4j2-uat.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN" monitorInterval="30">
 	<Properties>
-		<Property name="LOG_PATTERN">%d %-5p [%X{msgId}] %c - %m%n</Property>
+		<Property name="LOG_PATTERN">%d %-5p [%X{msgId}] %c - %m{nolookups}%n</Property>
 		<Property name="LOG_DIRECTORY">/u01/oracle/e11/opa12e11/mid/1213/user_projects/domains/aopa12e11_domain/connector-logs</Property>
 		<Property name="LOG_SUFFIX">_civil</Property>
 		<Property name="ERR_FILE_NAME">${LOG_DIRECTORY}/ccms_assess_service_adapter_err${LOG_SUFFIX}.log</Property>


### PR DESCRIPTION
The fix is to disable nslookup feature in log4j xml file.