### PR TITLE
Problem/cpb 115 excessive log files generated prod only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,125 +45,125 @@ jobs:
       - persist_to_workspace:
           root: ~/laa-ccms-service-adapter
           paths:
-            - target/assess-service-adapter.jar
+            - target/assess-service-adapter.war
 
-  build-and-push-docker-image:
-    executor: docker/machine
-    steps:
-      - checkout
-      - attach_workspace:
-          at: /tmp/workspace
-      - run:
-          name: Install aws cli
-          command: |
-            sudo apt-get update
-            sudo apt-get -y install awscli
-            aws --version
-      - run:
-          name: Copy build artifacts from workspace
-          command: cp -r /tmp/workspace/target /home/circleci/project/
-      - docker/build:
-          image: 902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-ccms-service-adapter
-          tag: latest
-      - service-adapter/ecr_login
-      - run:
-          name: Push container
-          command: |
-            export SHORT_HASH=${CIRCLE_SHA1:0:7}
-            docker tag 902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-ccms-service-adapter:latest 902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-ccms-service-adapter:$SHORT_HASH
-            if [ "${CIRCLE_BRANCH}" == "main" ]; then
-              # We want all of the tags pushed
-              docker push 902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-ccms-service-adapter
-            else
-              docker push 902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-ccms-service-adapter:$SHORT_HASH
-            fi
-
-  deploy:
-    executor: docker/machine
-    parameters:
-      aws-account:
-        description: "Aws Acccount"
-        type: string
-    environment:
-      AWS_ACCOUNT=<<parameters.aws-account>>
-    steps:
-      - run:
-          name: Install aws cli
-          command: |
-            sudo apt-get update
-            sudo apt-get -y install awscli
-            aws --version
-      - run:
-          name: Set environment variables
-          command: |
-            export SHORT_HASH=${CIRCLE_SHA1:0:7}
-            echo "export SHORT_HASH=${CIRCLE_SHA1:0:7}" >> $BASH_ENV 
-      - service-adapter/aws-credentials
-      - aws-ecs/update-service:
-          family: 'laa-ccms-assessment-service-task-definition'
-          cluster-name: 'ccms-opa18-hub-cluster'
-          container-image-name-updates: 'container=laa-ccms-assessment-service-container,tag=${SHORT_HASH}'
-          service-name: 'laa-ccms-assessment-service-ecs-service'
-          force-new-deployment: true
-
-workflows:
-  version: 2
-  build-and-push:
-    jobs:
-      - build
-      - build-and-push-docker-image:
-          requires:
-            - build
-      - dev-approval:
-          type: approval
-          requires:
-            - build-and-push-docker-image
-          filters:
-            branches:
-              ignore: main
-      - deploy:
-          name: dev-deploy
-          aws-account: "411213865113"
-          requires:
-            - dev-approval
-          filters:
-            branches:
-              ignore: main
-      - test-approval:
-          type: approval
-          requires:
-            - dev-deploy
-          filters:
-            branches:
-              ignore: main
-      - deploy:
-          name: test-deploy
-          aws-account: "013163512034"
-          requires:
-            - test-approval
-          filters:
-            branches:
-              ignore: main
-      - deploy:
-          name: pre-prod-deploy
-          aws-account: "484221692666"
-          requires:
-            - build-and-push-docker-image
-          filters:
-            branches:
-              only: main
-      - prod-approval:
-          type: approval
-          requires:
-            - pre-prod-deploy
-          filters:
-            branches:
-              only: main
-      - deploy:
-          name: prod-deploy
-          aws-account: "842522700642"
-          requires:
-            - prod-approval
-          filters:
-            branches:
-              only: main
+#  build-and-push-docker-image:
+#    executor: docker/machine
+#    steps:
+#      - checkout
+#      - attach_workspace:
+#          at: /tmp/workspace
+#      - run:
+#          name: Install aws cli
+#          command: |
+#            sudo apt-get update
+#            sudo apt-get -y install awscli
+#            aws --version
+#      - run:
+#          name: Copy build artifacts from workspace
+#          command: cp -r /tmp/workspace/target /home/circleci/project/
+#      - docker/build:
+#          image: 902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-ccms-service-adapter
+#          tag: latest
+#      - service-adapter/ecr_login
+#      - run:
+#          name: Push container
+#          command: |
+#            export SHORT_HASH=${CIRCLE_SHA1:0:7}
+#            docker tag 902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-ccms-service-adapter:latest 902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-ccms-service-adapter:$SHORT_HASH
+#            if [ "${CIRCLE_BRANCH}" == "main" ]; then
+#              # We want all of the tags pushed
+#              docker push 902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-ccms-service-adapter
+#            else
+#              docker push 902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-ccms-service-adapter:$SHORT_HASH
+#            fi
+#
+#  deploy:
+#    executor: docker/machine
+#    parameters:
+#      aws-account:
+#        description: "Aws Acccount"
+#        type: string
+#    environment:
+#      AWS_ACCOUNT=<<parameters.aws-account>>
+#    steps:
+#      - run:
+#          name: Install aws cli
+#          command: |
+#            sudo apt-get update
+#            sudo apt-get -y install awscli
+#            aws --version
+#      - run:
+#          name: Set environment variables
+#          command: |
+#            export SHORT_HASH=${CIRCLE_SHA1:0:7}
+#            echo "export SHORT_HASH=${CIRCLE_SHA1:0:7}" >> $BASH_ENV
+#      - service-adapter/aws-credentials
+#      - aws-ecs/update-service:
+#          family: 'laa-ccms-assessment-service-task-definition'
+#          cluster-name: 'ccms-opa18-hub-cluster'
+#          container-image-name-updates: 'container=laa-ccms-assessment-service-container,tag=${SHORT_HASH}'
+#          service-name: 'laa-ccms-assessment-service-ecs-service'
+#          force-new-deployment: true
+#
+#workflows:
+#  version: 2
+#  build-and-push:
+#    jobs:
+#      - build
+#      - build-and-push-docker-image:
+#          requires:
+#            - build
+#      - dev-approval:
+#          type: approval
+#          requires:
+#            - build-and-push-docker-image
+#          filters:
+#            branches:
+#              ignore: main
+#      - deploy:
+#          name: dev-deploy
+#          aws-account: "411213865113"
+#          requires:
+#            - dev-approval
+#          filters:
+#            branches:
+#              ignore: main
+#      - test-approval:
+#          type: approval
+#          requires:
+#            - dev-deploy
+#          filters:
+#            branches:
+#              ignore: main
+#      - deploy:
+#          name: test-deploy
+#          aws-account: "013163512034"
+#          requires:
+#            - test-approval
+#          filters:
+#            branches:
+#              ignore: main
+#      - deploy:
+#          name: pre-prod-deploy
+#          aws-account: "484221692666"
+#          requires:
+#            - build-and-push-docker-image
+#          filters:
+#            branches:
+#              only: main
+#      - prod-approval:
+#          type: approval
+#          requires:
+#            - pre-prod-deploy
+#          filters:
+#            branches:
+#              only: main
+#      - deploy:
+#          name: prod-deploy
+#          aws-account: "842522700642"
+#          requires:
+#            - prod-approval
+#          filters:
+#            branches:
+#              only: main

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>uk.gov.justice.laa.ccms</groupId>
 	<artifactId>AssessServiceAdapter</artifactId>
 	<version>0.0.18-SNAPSHOT</version>
-<!--	<packaging>war</packaging>-->
+	<packaging>war</packaging>
 
 	<name>OPA10 to OPA 12 Assess Service Adapter</name>
 
@@ -23,7 +23,7 @@
 		<m2e.apt.activation>jdt_apt</m2e.apt.activation>
 		<maven.javadoc.skip>true</maven.javadoc.skip>
 		<cucumber.version>4.3.0</cucumber.version>
-		<log4j2.version>2.15.0</log4j2.version>
+<!--		<log4j2.version>2.15.0</log4j2.version>-->
 	</properties>
 
 	<dependencies>

--- a/src/main/resources/log4j2-prod.xml
+++ b/src/main/resources/log4j2-prod.xml
@@ -1,48 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN" monitorInterval="30">
-	<Properties>
-		<Property name="LOG_PATTERN">%d %-5p [%X{msgId}] %c - %m%n</Property>
-		<Property name="LOG_DIRECTORY">/u01/oracle/prod/opa12prod/mid/1213/user_projects/domains/opa12prod_domain/connector-logs</Property>
-		<Property name="LOG_SUFFIX">_civil</Property>
-		<Property name="ERR_FILE_NAME">${LOG_DIRECTORY}/ccms_assess_service_adapter_err${LOG_SUFFIX}.log</Property>
-		<Property name="DBG_FILE_NAME">${LOG_DIRECTORY}/ccms_assess_service_adapter_app${LOG_SUFFIX}.log</Property>
-		<Property name="LOG_LEVEL">INFO</Property>
-	</Properties>
+  <Properties>
+    <Property name="LOG_PATTERN">%d %-5p [%X{msgId}] %c - %m%n</Property>
+    <Property name="LOG_DIRECTORY">/u01/oracle/prod/opa12prod/mid/1213/user_projects/domains/opa12prod_domain/connector-logs</Property>
+    <Property name="LOG_SUFFIX">_civil</Property>
+    <Property name="ERR_FILE_NAME">${LOG_DIRECTORY}/ccms_assess_service_adapter_err${LOG_SUFFIX}.log</Property>
+    <Property name="DBG_FILE_NAME">${LOG_DIRECTORY}/ccms_assess_service_adapter_app${LOG_SUFFIX}.log</Property>
+    <Property name="LOG_LEVEL">INFO</Property>
+  </Properties>
 
-	<Appenders>
-		<Console name="stdout" target="SYSTEM_OUT" >
-			<PatternLayout pattern="${LOG_PATTERN}" />
-		</Console>
-		
-		<RollingFile name="errorfile" fileName="${ERR_FILE_NAME}" filePattern = "${ERR_FILE_NAME}.%d{yyyy-MM-dd}_%i" >
-			<PatternLayout pattern="${LOG_PATTERN}" />
-			<Policies>
-				<TimeBasedTriggeringPolicy />
-				<SizeBasedTriggeringPolicy size="10M" />
-			</Policies>
-			<DefaultRolloverStrategy max="5" />
-		</RollingFile>
-		
-		<RollingFile name="debugfile" fileName="${DBG_FILE_NAME}" filePattern="${DBG_FILE_NAME}.%d{yyyy-MM-dd}_%i" >
-			<PatternLayout pattern="${LOG_PATTERN}" />
-			<Policies>
-				<TimeBasedTriggeringPolicy />
-				<SizeBasedTriggeringPolicy size="10M" />
-			</Policies>
-			<DefaultRolloverStrategy max="5" />
-		</RollingFile>	
-	</Appenders>
+  <Appenders>
+    <Console name="stdout" target="SYSTEM_OUT" >
+      <PatternLayout pattern="${LOG_PATTERN}" />
+    </Console>
 
-	<Loggers>
-		<Logger name="uk.gov.justice" level="${LOG_LEVEL}" additivity="true">
-			<AppenderRef ref="stdout" />
-			<AppenderRef ref="debugfile" />
-			<AppenderRef ref="errorfile" level="warn" />
-		</Logger>
-		<Root level="info">
-			<AppenderRef ref="stdout" />
-			<AppenderRef ref="debugfile" />
-			<AppenderRef ref="errorfile" level="warn" />
-		</Root>
-	</Loggers>
+    <RollingFile name="errorfile" fileName="${ERR_FILE_NAME}" filePattern = "${ERR_FILE_NAME}.%d{yyyy-MM-dd}_%i" >
+      <PatternLayout pattern="${LOG_PATTERN}" />
+      <Policies>
+        <TimeBasedTriggeringPolicy />
+        <SizeBasedTriggeringPolicy size="10M" />
+      </Policies>
+      <DefaultRolloverStrategy max="5" />
+    </RollingFile>
+
+    <RollingFile name="debugfile" fileName="${DBG_FILE_NAME}" filePattern="${DBG_FILE_NAME}.%d{yyyy-MM-dd}_%i" >
+      <PatternLayout pattern="${LOG_PATTERN}" />
+      <Policies>
+        <TimeBasedTriggeringPolicy />
+        <SizeBasedTriggeringPolicy size="10M" />
+      </Policies>
+      <DefaultRolloverStrategy max="5" />
+    </RollingFile>
+  </Appenders>
+
+  <Loggers>
+    <Logger name="uk.gov.justice" level="${LOG_LEVEL}" additivity="true">
+      <AppenderRef ref="stdout" />
+      <AppenderRef ref="debugfile" />
+      <AppenderRef ref="errorfile" level="warn" />
+    </Logger>
+    <Logger name="org.apache.cxf.services" level="warn" additivity="true">
+      <AppenderRef ref="stdout" />
+      <AppenderRef ref="debugfile" />
+      <AppenderRef ref="errorfile" level="warn" />
+    </Logger>
+    <Root level="info">
+      <AppenderRef ref="stdout" />
+      <AppenderRef ref="debugfile" />
+      <AppenderRef ref="errorfile" level="warn" />
+    </Root>
+  </Loggers>
 </Configuration>


### PR DESCRIPTION
### This branch should not be merged into main
this is specifically for weblogic 6 degrees production environment

Before deploying to production, the log4j2 scan script should be executed with --fix to remove the jndi lookup class in log4j2-core jar