### PR TITLE
fix(cc-1457): change docker timezone to Europe/London to sync with 6D…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,5 @@ COPY target/assess-service-adapter.jar assess-service-adapter.jar
 
 EXPOSE 8080
 
-ENV TZ=UTC
+ENV TZ=Europe/London
 ENTRYPOINT ["java","-jar","assess-service-adapter.jar"]


### PR DESCRIPTION
What is changed
The timezone specified in the connector Dockerfile has been changed to Europe/London

Why
Currently the containers are running in UTC. This means they do not follow daylight saving changes in the UK. This contrasts with the servers hosted by 6DG, which will switch between BST and GMT accordingly.
By setting the container timezone to Europe/London it will now match the 6DG servers.